### PR TITLE
KAN-7: create dashboard sidebar ui

### DIFF
--- a/frontend/src/components/SideBar.tsx
+++ b/frontend/src/components/SideBar.tsx
@@ -1,0 +1,40 @@
+import { Button } from "./ui/button";
+import { DashboardIcon, ReaderIcon, GearIcon } from "@radix-ui/react-icons";
+
+const SideBar = () => {
+  return (
+    <div className="sticky min-w-max p-4 border-dashed border-r-2">
+      <ul className="w-full h-full flex flex-col mx-2 gap-1">
+        <li>
+          <Button
+            variant="ghost"
+            className="flex gap-2 hover:text-destructive hover:bg-destructive-foreground"
+          >
+            <DashboardIcon />
+            Dashboard
+          </Button>
+        </li>
+        <li>
+          <Button
+            variant="ghost"
+            className="flex gap-2 hover:text-destructive hover:bg-destructive-foreground"
+          >
+            <ReaderIcon />
+            Logs
+          </Button>
+        </li>
+        <li>
+          <Button
+            variant="ghost"
+            className="flex gap-2 hover:text-destructive hover:bg-destructive-foreground"
+          >
+            <GearIcon />
+            Settings
+          </Button>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default SideBar;


### PR DESCRIPTION
put these sideby side images
PR: create dashboard sidebar ui

**Done**:
- [x] sidebar

**Screenshot**: 
1. Standard
![Screenshot from 2024-06-04 13-29-57](https://github.com/GR7ME/zakipoint/assets/84652371/4670fa4d-094c-4eaf-be7f-8dc34cb1e8f4)

2. Hover
![Screenshot from 2024-06-04 13-30-29](https://github.com/GR7ME/zakipoint/assets/84652371/c07a3292-2506-46d5-a369-7c79f49e790e)
